### PR TITLE
Fix. css 최종 수정 완료

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,19 +13,12 @@ p {
   margin: 0;
 }
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-	-webkit-appearance: inner-spin-button;
-    opacity: 1;
-}
-
 .container {
   background-color: white;
   width: 1170px;
   padding: 15px;
   min-height: 200px;
   margin: 0 auto;
-  
 }
 
 #inputForm {


### PR DESCRIPTION
Chrome에서 -webkit-appearance 지원 종료에 따른 number input의 inner-spin-button, outer-spin-button 항상 표시 css 삭제